### PR TITLE
Refactor AccountsBloc

### DIFF
--- a/lib/src/features/accounts/data/repositories/local_account_repository.dart
+++ b/lib/src/features/accounts/data/repositories/local_account_repository.dart
@@ -47,6 +47,7 @@ class LocalAccountRepository extends AccountRepository {
     if (_items.contains(item) || _containsItemWithSameName(item)) {
       return Future.value(left(DuplicateError()));
     }
+    _items.removeWhere((element) => element.id == item.id);
     _items.add(item);
     save();
     notifyListeners();
@@ -66,6 +67,10 @@ class LocalAccountRepository extends AccountRepository {
 
   bool _containsItemWithSameName(Account account) {
     return _items.where((e) => e.name == account.name).isNotEmpty;
+  }
+
+  bool _containsItemWithSameId(Account account) {
+    return _items.where((e) => e.id == account.id).isNotEmpty;
   }
 
   @override

--- a/lib/src/features/accounts/presentation/bloc/accounts_event.dart
+++ b/lib/src/features/accounts/presentation/bloc/accounts_event.dart
@@ -9,10 +9,10 @@ class LoadAccounts extends AccountsEvent {
   List<Object?> get props => [];
 }
 
-class AccountAddedOrUpdated extends AccountsEvent {
+class AccountAdded extends AccountsEvent {
   final Account account;
 
-  AccountAddedOrUpdated(this.account);
+  AccountAdded(this.account);
 
   @override
   List<Object?> get props => [account];

--- a/lib/src/features/accounts/presentation/pages/account_edit.dart
+++ b/lib/src/features/accounts/presentation/pages/account_edit.dart
@@ -90,9 +90,7 @@ class _AccountEditState extends State<AccountEdit> {
                 child: Text(widget.saveButtonLabel),
                 onPressed: () {
                   if (_formKey.currentState!.validate()) {
-                    context
-                        .read<AccountsBloc>()
-                        .add(AccountAddedOrUpdated(Account(
+                    context.read<AccountsBloc>().add(AccountAdded(Account(
                           id: accountId,
                           type: 'trello',
                           name: nameController.text,

--- a/lib/src/injection_container.dart
+++ b/lib/src/injection_container.dart
@@ -17,6 +17,7 @@ Future<void> init() async {
         addAccount: sl(),
         removeAccount: sl(),
         getAllAccounts: sl(),
+        accountRepository: sl(),
       ));
   sl.registerLazySingleton(() => AddAccount(sl()));
   sl.registerLazySingleton(() => RemoveAccount(sl()));

--- a/test/src/features/accounts/data/repositories/local_account_repository_test.dart
+++ b/test/src/features/accounts/data/repositories/local_account_repository_test.dart
@@ -37,6 +37,11 @@ void main() {
       id: objectId3, type: 'type', name: 'name1', key: 'key', secret: 'secret');
   var account3Json =
       '{"id":"$objectId3","type":"type","name":"name1","key":"key","secret":"secret"}';
+  // account 4 - a distinct account with the same id as account 1
+  Account account4 = Account(
+      id: objectId1, type: 'type', name: 'name4', key: 'key', secret: 'secret');
+  var account4Json =
+      '{"id":"$objectId1","type":"type","name":"name4","key":"key","secret":"secret"}';
   late MockSharedPreferences sharedPreferences;
   late AccountsLocalDataSource dataSource;
 
@@ -208,6 +213,36 @@ void main() {
           //then
           verifyConstructorLoads();
           verifyNeverSaves();
+          verifyNoMoreInteractions(sharedPreferences);
+        });
+      });
+      group('when account with same id is already present', () {
+        setUp(() => givenStartingAccounts([accountModel1, accountModel2]));
+        test('replaces the account', () async {
+          //given
+          var repository = createRepository();
+          //when
+          await repository.add(account4);
+          //then
+          await verifyContents(repository, [account2, account4]);
+        });
+        test('returns added account', () async {
+          //given
+          var repository = createRepository();
+          //when
+          var result = await repository.add(account4);
+          //then
+          expect(result.isRight(), isTrue);
+          result.map((account) => expect(account, account4));
+        });
+        test('save accounts', () async {
+          //given
+          var repository = createRepository();
+          //when
+          await repository.add(account4);
+          //then
+          verifyConstructorLoads();
+          verifySaves([account2Json, account4Json]);
           verifyNoMoreInteractions(sharedPreferences);
         });
       });

--- a/test/src/features/accounts/presentation/bloc/accounts_bloc_test.dart
+++ b/test/src/features/accounts/presentation/bloc/accounts_bloc_test.dart
@@ -1,95 +1,89 @@
 import 'package:bloc_test/bloc_test.dart';
-import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/annotations.dart';
-import 'package:mockito/mockito.dart';
 import 'package:objectid/objectid.dart';
-import 'package:worknotes/src/features/accounts/domain/entities/account.dart';
-import 'package:worknotes/src/features/accounts/domain/usecases/add_account.dart';
-import 'package:worknotes/src/features/accounts/domain/usecases/get_all_accounts.dart';
-import 'package:worknotes/src/features/accounts/domain/usecases/remove_account.dart';
-import 'package:worknotes/src/features/accounts/presentation/bloc/accounts_bloc.dart';
-import 'package:worknotes/src/features/accounts/presentation/bloc/accounts_event.dart';
-import 'package:worknotes/src/features/accounts/presentation/bloc/accounts_state.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:worknotes/src/features/accounts/accounts.dart';
 
-import 'accounts_bloc_test.mocks.dart';
+void main() async {
+  final sharedPreferences = await SharedPreferences.getInstance();
 
-@GenerateMocks([AddAccount, RemoveAccount, GetAllAccounts])
-void main() {
-  late AccountsBloc accountsBloc;
-  setUp(() {
-    final mockAddAccount = MockAddAccount();
-    final mockRemoveAccount = MockRemoveAccount();
-    final mockGetAllAccounts = MockGetAllAccounts();
-    when(mockGetAllAccounts.call(any))
-        .thenAnswer((_) => Future.value(right([])));
-    when(mockAddAccount.call(any)).thenAnswer((realInvocation) =>
-        Future.value(right(realInvocation.positionalArguments[0])));
-    when(mockRemoveAccount.call(any)).thenAnswer((realInvocation) =>
-        Future.value(right(realInvocation.positionalArguments[0])));
-    accountsBloc = AccountsBloc.load(
-      addAccount: mockAddAccount,
-      removeAccount: mockRemoveAccount,
-      getAllAccounts: mockGetAllAccounts,
+  AccountsBloc accountsBloc() {
+    final ds = SharedPreferencesAccountsLocalDataSource(sharedPreferences);
+    final repository = LocalAccountRepository(ds);
+    return AccountsBloc.load(
+      accountRepository: repository,
+      addAccount: AddAccount(repository),
+      removeAccount: RemoveAccount(repository),
+      getAllAccounts: GetAllAccounts(repository),
     );
-  });
+  }
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
   test('Initial state is empty', () {
-    expect(accountsBloc.state.accounts.isEmpty, isTrue);
+    expect(accountsBloc().state.accounts.isEmpty, isTrue);
   });
+
   final objectIdAlpha = ObjectId();
   final objectIdBeta = ObjectId();
   Account accountAlphaV1 = Account(
       id: objectIdAlpha,
-      type: 'type 1',
-      name: 'name 1',
-      key: 'key 1',
-      secret: 'secret 1');
+      type: 'alpha',
+      name: 'v1',
+      key: 'key',
+      secret: 'secret');
   Account accountAlphaV2 = Account(
       id: objectIdAlpha,
-      type: 'type 2',
-      name: 'name 2',
-      key: 'key 2',
-      secret: 'secret 2');
+      type: 'alpha',
+      name: 'v2',
+      key: 'key',
+      secret: 'secret');
   Account accountBetaV1 = Account(
-      id: objectIdBeta,
-      type: 'type 1',
-      name: 'name 1',
-      key: 'key 1',
-      secret: 'secret 1');
+      id: objectIdBeta, type: 'beta', name: 'v1', key: 'key', secret: 'secret');
+
   blocTest<AccountsBloc, AccountsState>(
     'Add accounts',
-    build: () => accountsBloc,
+    build: accountsBloc,
     seed: () => const AccountsState([]),
     act: (bloc) {
-      bloc.add(AccountAddedOrUpdated(accountAlphaV1));
-      bloc.add(AccountAddedOrUpdated(accountBetaV1));
+      bloc.add(AccountAdded(accountAlphaV1));
     },
     expect: () => [
       AccountsState([accountAlphaV1]),
-      AccountsState([accountAlphaV1, accountBetaV1])
     ],
   );
   blocTest<AccountsBloc, AccountsState>(
     'Add an account where id already exists is an update',
-    build: () => accountsBloc,
-    seed: () => AccountsState([accountAlphaV1]),
-    act: (bloc) => bloc.add(AccountAddedOrUpdated(accountAlphaV2)),
+    build: accountsBloc,
+    seed: () => const AccountsState([]),
+    act: (bloc) {
+      bloc.add(AccountAdded(accountAlphaV1));
+      bloc.add(AccountAdded(accountAlphaV2));
+    },
     expect: () => [
-      AccountsState([accountAlphaV2])
+      AccountsState([accountAlphaV2]) // replaces v1
     ],
   );
   blocTest<AccountsBloc, AccountsState>(
     'Remove an account',
-    build: () => accountsBloc,
-    seed: () => AccountsState([accountAlphaV1]),
-    act: (bloc) => bloc.add(AccountRemoved(accountAlphaV1)),
-    expect: () => const [AccountsState([])],
+    build: accountsBloc,
+    seed: () => const AccountsState([]),
+    act: (bloc) {
+      bloc.add(AccountAdded(accountAlphaV1));
+      bloc.add(AccountRemoved(accountAlphaV1));
+    },
+    expect: () => [const AccountsState([])],
   );
   blocTest<AccountsBloc, AccountsState>(
     'Removing an account that doesn\'t exist is ignored',
-    build: () => accountsBloc,
+    build: accountsBloc,
     seed: () => AccountsState([accountAlphaV1]),
-    act: (bloc) => bloc.add(AccountRemoved(accountBetaV1)),
-    expect: () => [], // no changes
+    act: (bloc) {
+      bloc.add(AccountAdded(accountAlphaV1));
+      bloc.add(AccountRemoved(accountBetaV1));
+    },
+    expect: () => [
+      AccountsState([accountAlphaV1])
+    ],
   );
 }


### PR DESCRIPTION
- now uses events to load accounts when they are modified rather than attempting to maintain its own state.
- rename `AccountAddedOrUpdated` as `AccountAdded`
- adding an account to the repository where there is already one with the same id, replaces it
